### PR TITLE
add test case for ServerTableDescriptor

### DIFF
--- a/ams/server/src/test/java/com/netease/arctic/server/dashboard/TestServerTableDescriptor.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/dashboard/TestServerTableDescriptor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.server.dashboard;
+
+import com.netease.arctic.BasicTableTestHelper;
+import com.netease.arctic.TableTestHelper;
+import com.netease.arctic.ams.api.TableFormat;
+import com.netease.arctic.catalog.BasicCatalogTestHelper;
+import com.netease.arctic.catalog.CatalogTestHelper;
+import com.netease.arctic.hive.catalog.HiveCatalogTestHelper;
+import com.netease.arctic.hive.catalog.HiveTableTestHelper;
+import com.netease.arctic.server.dashboard.model.DDLInfo;
+import com.netease.arctic.server.table.AMSTableTestBase;
+import com.netease.arctic.server.table.TableServiceTestBase;
+import com.netease.arctic.table.ArcticTable;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class TestServerTableDescriptor extends AMSTableTestBase {
+
+  @Parameterized.Parameters(name = "{0}, {1}")
+  public static Object[] parameters() {
+    return new Object[][] {{new BasicCatalogTestHelper(TableFormat.MIXED_ICEBERG),
+        new BasicTableTestHelper(true, true)},
+        {new HiveCatalogTestHelper(TableFormat.MIXED_HIVE, TEST_HMS.getHiveConf()),
+            new HiveTableTestHelper(true, true)}};
+  }
+
+  public TestServerTableDescriptor(CatalogTestHelper catalogTestHelper,
+                                   TableTestHelper tableTestHelper) {
+    super(catalogTestHelper, tableTestHelper, true);
+  }
+
+  @Test
+  public void getTableOperations() {
+    ServerTableDescriptor serverTableDescriptor = new ServerTableDescriptor(tableService());
+    ArcticTable arcticTable = tableService().loadTable(serverTableIdentifier());
+    arcticTable.updateProperties().set("key", "value1").commit();
+    List<DDLInfo> tableOperations = serverTableDescriptor.getTableOperations(serverTableIdentifier());
+    Assert.assertEquals(1, tableOperations.size());
+    DDLInfo ddlInfo = tableOperations.get(0);
+    System.out.println(ddlInfo);
+    arcticTable.updateProperties().set("key", "value2").commit();
+    tableOperations = serverTableDescriptor.getTableOperations(serverTableIdentifier());
+    Assert.assertEquals(2, tableOperations.size());
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

*(For example: The Arctic Flink dataStream API has already supported this configuration: 'scan.startup.mode', but it is not available with Flink SQL. We should expose this configuration to users when they are using Flink SQL.)*

## Brief change log

*(For example:)*
  - *Add the 'scan.startup.mode' configuration to the ArcticScanContext in the flink modules*
  - *The flink 1.12 and 1.14 versions are affected.*
  - *Add the documentation in the flink chapter*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
